### PR TITLE
feature: Overhaul styles, fix autogrouping behavior

### DIFF
--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -4,25 +4,57 @@ Notebook[{
 	Cell[
 		StyleData["Input"],
 		StyleKeyMapping -> {
-			"/" -> "ChatGPTUserInput",
+			"/" -> "ChatUserInput",
 			"=" -> "WolframAlphaShort",
 			">" -> "ExternalLanguageDefault",
 			"*" -> "Item"
 		}
 	],
 
+	Cell[
+		StyleData["ChatAssistantOutput", StyleDefinitions -> StyleData["Output"]],
+		CellGroupingRules -> "OutputGrouping",
+		CellFrame->{{2, False}, {False, False}},
+		CellFrameStyle -> Dashed,
+		CellFrameColor->RGBColor[1, 0.7, 0.1]
+	],
+
+	Cell[
+		StyleData["ChatAssistantText", StyleDefinitions -> StyleData["Text"]],
+		CellGroupingRules -> "OutputGrouping",
+		CellFrame->{{2, False}, {False, False}},
+		CellFrameStyle -> Dashed,
+		CellFrameColor->RGBColor[1, 0.7, 0.1]
+	],
+
+	Cell[
+		StyleData["ChatAssistantProgram", StyleDefinitions -> StyleData["Program"]],
+		CellGroupingRules -> "OutputGrouping",
+		CellFrame->{{2, False}, {False, False}},
+		CellFrameStyle -> Dashed,
+		CellFrameColor->RGBColor[1, 0.7, 0.1]
+	],
+
+	Cell[
+		StyleData["ChatAssistantExternalLanguage", StyleDefinitions -> StyleData["ExternalLanguage"]],
+		CellGroupingRules -> "OutputGrouping",
+		CellFrame->{{2, False}, {False, False}},
+		CellFrameStyle -> Dashed,
+		CellFrameColor->RGBColor[1, 0.7, 0.1]
+	],
+
 	(*================================*)
-	(* ChatGPT Input Cell Styles      *)
+	(* Chat Input Cell Styles         *)
 	(*================================*)
 
 	Cell[
 		StyleData[
-			"ChatGPTUserInput",
-			StyleDefinitions -> StyleData["ChatGPTInputBase"]
+			"ChatUserInput",
+			StyleDefinitions -> StyleData["ChatInputBase"]
 		],
 		StyleKeyMapping -> {
 			"Backspace" -> "Input",
-			"/" -> "ChatGPTSystemInput",
+			"/" -> "ChatSystemInput",
 			" " -> "Text",
 			"*" -> "Item"
 		},
@@ -47,11 +79,11 @@ Notebook[{
 
 	Cell[
 		StyleData[
-			"ChatGPTSystemInput",
-			StyleDefinitions -> StyleData["ChatGPTInputBase"]
+			"ChatSystemInput",
+			StyleDefinitions -> StyleData["ChatInputBase"]
 		],
 		StyleKeyMapping -> {
-			"Backspace" -> "ChatGPTInput"
+			"Backspace" -> "ChatUserInput"
 		},
 		BackgroundAppearance -> FrontEnd`FileName[{"WolframAlphaClient"}, "NLInputQuery.9.png"],
 		CellDingbat -> PaneBox[
@@ -71,11 +103,23 @@ Notebook[{
 		]
 	],
 
-	(* Deprecated cell style. ChatGPTInput was replaced with ChatGPTUserInput. *)
+	(* Deprecated cell styles. ChatGPTInput was replaced with ChatGPTUserInput and then with ChatUserInput. *)
 	Cell[
 		StyleData[
 			"ChatGPTInput",
-			StyleDefinitions -> StyleData["ChatGPTUserInput"]
+			StyleDefinitions -> StyleData["ChatUserInput"]
+		]
+	],
+	Cell[
+		StyleData[
+			"ChatGPTUserInput",
+			StyleDefinitions -> StyleData["ChatUserInput"]
+		]
+	],
+	Cell[
+		StyleData[
+			"ChatGPTSystemInput",
+			StyleDefinitions -> StyleData["ChatSystemInput"]
 		]
 	],
 
@@ -84,7 +128,7 @@ Notebook[{
 	(*--------------------------------*)
 
 	Cell[
-		StyleData["ChatGPTInputBase", StyleDefinitions -> StyleData["Input"]],
+		StyleData["ChatInputBase", StyleDefinitions -> StyleData["Input"]],
 		CellMargins -> {{66, 21}, {5, 10}},
 		CellDingbatMargin -> -25,
 		CellEvaluationFunction :> (

--- a/Source/UI.wl
+++ b/Source/UI.wl
@@ -142,20 +142,14 @@ SetFallthroughError[promptProcess]
 promptProcess[cell0_] := ConfirmReplace[cell0, {
 	Cell[CellGroupData[___], ___] :> Nothing,
 
-	Cell[_, "Subsubsection", ___] :> Nothing,
-
-	Cell[_, "Print", ___] :> Nothing,
-
-	(* FIXME: Inlude these *)
-	Cell[_, "Program" | "ExternalLanguage", ___] :> Nothing,
-
-	Cell[expr_, "Input" | "ChatGPTInput" | "ChatGPTUserInput" | "Text", ___]
+	Cell[expr_, "ChatUserInput" |
+				(*Deprecated names*) "ChatGPTInput" | "ChatGPTUserInput", ___]
 		:> <| "role" -> "user", "content" -> promptCellDataToString[expr] |>,
 
-	Cell[expr_, "Output", ___]
+	Cell[expr_, "ChatAssistantOutput" | "ChatAssistantText" | "ChatAssistantProgram" | "ChatAssistantExternalLanguage", ___]
 		:> <| "role" -> "assistant", "content" -> promptCellDataToString[expr] |>,
 
-	Cell[expr_, "ChatGPTSystemInput", ___]
+	Cell[expr_, "ChatSystemInput" | (*Deprecated names*) "ChatGPTSystemInput", ___]
 		:> <| "role" -> "system", "content" -> promptCellDataToString[expr] |>,
 
 	(* Ignore unrecognized cell types. *)
@@ -208,13 +202,13 @@ processResponse[response_?StringQ] := Module[{
 },
 	Scan[
 		Replace[{
-			s_?StringQ :> CellPrint @ Cell[StringTrim[s], "Text"],
-			Code[s_?StringQ] :> CellPrint @ Cell[s, "Program"],
-			Code[s_?StringQ, "Wolfram"] :> CellPrint @ Cell[s, "Input"],
+			s_?StringQ :> CellPrint @ Cell[StringTrim[s], "ChatAssistantText"],
+			Code[s_?StringQ] :> CellPrint @ Cell[s, "ChatAssistantProgram"],
+			Code[s_?StringQ, "Wolfram"] :> CellPrint @ Cell[BoxData[s], "ChatAssistantOutput"],
 			Code[s_?StringQ, lang_?StringQ]
 				:> CellPrint @ Cell[
 					s,
-					"ExternalLanguage",
+					"ChatAssistantExternalLanguage",
 					CellEvaluationLanguage -> Replace[lang, {
 						"Bash" -> "Shell"
 					}]


### PR DESCRIPTION
* Add new ChatAssistantText, ChatAssistantOutput, ChatAssistantProgram, and ChatAssistantExternalLangauge cell styles

* Deprecate the ChatGPTUserInput and ChatGPTSystemInput styles in favour of new ChatUserInput and ChatSystemInput cell styles

* Rename ChatGPTInputBase to ChatInputBase

* Changed set of cells included in prompt to only include cells with the ChatAssistant* and Chat(User|System)Input cell styles

* Changed output cell types produced from parsing the ChatGPT response to only include ChatAssistant* cell styles.