### PR TITLE
feature: Add $ChatContextCellStyles for specifying custom cell styles to include as context

### DIFF
--- a/Source/Chatbook.wl
+++ b/Source/Chatbook.wl
@@ -15,6 +15,12 @@ GU`SetUsage[$ChatInputPost, "$ChatInputPost is a string that is appended to the 
 GU`SetUsage[$DefaultChatSystemPre, "$DefaultChatSystemPre is the default value of $ChatSystemPre"]
 GU`SetUsage[$DefaultChatInputPost, "$ChatInputPost is the default value of $ChatInputPost"]
 
+GU`SetUsage[$ChatContextCellStyles, "
+$ChatContextCellStyles specifies additional cell styles to include as context to a chat input.
+
+Cells with one of the built-in chat cell styles are always included as context.
+"]
+
 
 Begin["`Private`"]
 
@@ -43,6 +49,8 @@ Protect[{$DefaultChatSystemPre, $DefaultChatInputPost}]
 
 $ChatSystemPre = $DefaultChatSystemPre
 $ChatInputPost = $DefaultChatInputPost
+
+$ChatContextCellStyles = <||>
 
 
 End[] (* End `Private` *)

--- a/Source/Errors.wl
+++ b/Source/Errors.wl
@@ -4,12 +4,23 @@ Needs["GeneralUtilities`" -> "GU`"]
 
 GU`SetUsage[ChatbookError, "ChatbookError represents an error in a Chatbook operation"]
 
+ChatbookWarning
+
 Begin["`Private`"]
 
 Needs["ConnorGray`Chatbook`ErrorUtils`"]
 
 CreateErrorType[ChatbookError, {}]
 
+(*====================================*)
+
+SetFallthroughError[ChatbookWarning]
+
+ChatbookWarning[formatStr_?StringQ, args___] :=
+	Print[
+		Style["warning: ", Darker[Yellow]],
+		ToString @ StringForm[formatStr, args]
+	]
 
 End[]
 


### PR DESCRIPTION

This is mostly intended to be a flexible way to experiment which the UX around which cell styles get included in the chat context.