### PR TITLE
feature: Streaming response writing

### DIFF
--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -7,6 +7,9 @@ PacletObject[<|
 	"Description" -> "ChatGPT + Wolfram Notebooks",
 	"Extensions" -> {
 		{"Kernel", "Root" -> "Source", "Context" -> "ConnorGray`Chatbook`"},
+		{"Kernel",
+			"Root" -> "SourceSSE",
+			"Context" -> "ConnorGray`ServerSentEventUtils`"},
 		{"FrontEnd"},
 		{"Documentation", "Language" -> "English"}
 	}

--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ Wolfram code in the chat output can be evaluated in place immediately:
 [ExternalEvaluate]: https://reference.wolfram.com/language/ref/ExternalEvaluate
 
 
+### Contributing
+
+See [**Development.md**](./docs/Development.md) for instructions on how to
+perform common development tasks when contributing to this project.

--- a/Source/Debug.wl
+++ b/Source/Debug.wl
@@ -1,0 +1,11 @@
+BeginPackage["ConnorGray`Chatbook`Debug`"]
+
+$LastRequest
+
+$LastRequestChatMessages
+
+$LastRequestParameters
+
+$LastResponse
+
+EndPackage[]

--- a/Source/ErrorUtils.wl
+++ b/Source/ErrorUtils.wl
@@ -78,6 +78,16 @@ $RaiseThrowTag
 
 $RegisteredErrorTags = <||>
 
+(*------------------------------------------*)
+(* Experiment with Raise => Fail rebranding *)
+(*------------------------------------------*)
+
+Fail2 = Raise
+FailAssert = RaiseAssert
+WrapFailed = WrapRaised
+FailConfirm = RaiseConfirm
+FailConfirmMatch = RaiseConfirmMatch
+
 (*====================================*)
 (* Advice                             *)
 (*====================================*)
@@ -379,6 +389,8 @@ FailurePattern[tags0_?TagsQ] :=
 (* Convenience Functions                                  *)
 (*========================================================*)
 
+Attributes[RaiseConfirm] = {HoldFirst}
+
 RaiseConfirm[expr_] :=
 	Replace[expr, {
 		f_Failure :> Raise[f],
@@ -434,6 +446,7 @@ RaiseAssert::assertfail = "``"
 
 RaiseAssert[
 	cond_,
+	assoc : _?AssociationQ : <||>,
 	formatStr_?StringQ,
 	formatArgs___
 ] :=
@@ -444,11 +457,14 @@ RaiseAssert[
 			"RaiseAssert[..] failed: " <> ToString[StringForm @@ {formatStr, formatArgs}]
 		];
 
-		Raise @ Failure[AssertFailedError, <|
-			"MessageTemplate" -> "RaiseAssert[..] failed: " <> formatStr,
-			"MessageParameters" -> {formatArgs},
-			"AssertConditionExpression" -> HoldForm[cond]
-		|>]
+		Raise @ Failure[AssertFailedError, Join[
+			<|
+				"MessageTemplate" -> "RaiseAssert[..] failed: " <> formatStr,
+				"MessageParameters" -> {formatArgs},
+				"AssertConditionExpression" -> HoldForm[cond]
+			|>,
+			assoc
+		]]
 	]
 
 RaiseAssert[cond_] :=

--- a/Source/Streaming.wl
+++ b/Source/Streaming.wl
@@ -1,0 +1,199 @@
+(*
+	This file contains functions for working with streaming chat response
+*)
+
+BeginPackage["ConnorGray`Chatbook`Streaming`"]
+
+Needs["GeneralUtilities`" -> "GU`"]
+
+GU`SetUsage[CreateChatEventToOutputEventGenerator, "
+CreateChatEventToOutputEventGenerator[] returns a generator function, which
+should be called with parsed chat server sent events, and will return either
+Missing['IncompleteData'], or a list of parsed chat output event structures.
+
+The returned generator function is a closure that maintains internal state
+between calls.
+"]
+
+
+Begin["`Private`"]
+
+Needs["ConnorGray`Chatbook`Errors`"]
+Needs["ConnorGray`Chatbook`ErrorUtils`"]
+
+(*========================================================*)
+
+SetFallthroughError[CreateChatEventToOutputEventGenerator]
+
+(*
+	The returned generator function can currently return the following events:
+
+		* "Write"["<...>"]
+		* "BeginCodeBlock"["<spec>"]
+		* "BeginText"
+*)
+CreateChatEventToOutputEventGenerator[] := Module[{
+	$state
+},
+	$state["Buffer"] = "";
+	$state["CurrentOutputType"] = None;
+
+	$state[args___] := Raise[
+		ChatbookError,
+		"Invalid chat event to output event $state args: ``",
+		{args}
+	];
+
+	Function[ssevent, handleChatEvent[$state, ssevent]]
+]
+
+(*------------------------------------*)
+
+SetFallthroughError[handleChatEvent]
+
+handleChatEvent[
+	$state_Symbol,
+	ssevent_?AssociationQ
+] := Module[{
+	data = ssevent,
+	outputEvents = {}
+},
+	RaiseAssert[
+		MatchQ[data, _?AssociationQ],
+		"Unexpected chat streaming response JSON parse result: ``",
+		InputForm[json]
+	];
+
+	data = ConfirmReplace[data, {
+		KeyValuePattern[{
+			(* TODO: What about other possible choices? *)
+			"choices" -> {firstChoice_, ___}
+		}] :> firstChoice,
+		other_ :> Raise[
+			ChatbookError,
+			"Unexpected chat streaming response object form: ``",
+			InputForm[other]
+		]
+	}];
+
+	ConfirmReplace[data, {
+		KeyValuePattern[{
+			"delta" -> KeyValuePattern[{
+				"content" -> text_?StringQ
+			}]
+		}] :> (
+			(* Print["Chunk: ", InputForm[text]]; *)
+			$state["Buffer"] = StringJoin[$state["Buffer"], text];
+		),
+		(* FIXME: Handle this change in role by changing cell type if necessary? *)
+		KeyValuePattern[{
+			"delta" -> KeyValuePattern[{
+				"role" -> "assistant"
+			}]
+		}] :> Null,
+		(* FIXME: Handle this streaming end better. *)
+		KeyValuePattern[{
+			"delta" -> <||>,
+			"finish_reason" -> "stop"
+		}] :> (
+			(*
+				If there is any remaining data in the buffer that wasn't
+				written out, write it out now. This can happen if the last token
+				is a string that is ambiguous to parse (e.g. "`").
+			*)
+			If[$state["Buffer"] =!= "",
+				(* FIXME: Test this case. *)
+				AppendTo[outputEvents, "Write"[$state["Buffer"]]];
+				$state["Buffer"] = "";
+			];
+		),
+		other_ :> Raise[
+			ChatbookError,
+			"Unexpected chat streaming response object form: ``",
+			InputForm[other]
+		]
+	}];
+
+	(*--------------------------------*)
+	(* Process the buffer.            *)
+	(*--------------------------------*)
+
+	RaiseAssert[StringQ[$state["Buffer"]]];
+
+	While[$state["Buffer"] =!= "",
+		(* Print["Buffer => ", InputForm[$state["Buffer"]]]; *)
+
+		RaiseAssert[StringQ[$state["Buffer"]]];
+
+		StringReplace[$state["Buffer"], {
+			StartOfString ~~ prefix:Repeated[Except["`" | "\n"]] ~~ rest___ ~~ EndOfString :> (
+				AppendTo[outputEvents, "Write"[prefix]];
+				$state["Buffer"] = rest;
+			),
+			(* Recognize incomplete input that might be a ``` code block start
+				or end marker. *)
+			StartOfString ~~ RepeatedNull["\n", 1] ~~ Repeated["`", {1, 2}] ~~ EndOfString :> (
+				(*
+					We don't have enough buffered data to know if we should
+					start or end a code block or not. Break out of the buffer
+					processing loop until we recieve more input.
+				*)
+				Break[];
+			),
+			(*--------------------------------------------------*)
+			(* Recognize a ``` that starts or ends a code block *)
+			(*--------------------------------------------------*)
+			StartOfString
+			~~ RepeatedNull["\n", 1] ~~ "```" ~~ spec:RepeatedNull[Except["`" | "\n"]]
+			~~ RepeatedNull["\n", 1] ~~ rest___ ~~ EndOfString :> (
+				ConfirmReplace[$state["CurrentOutputType"], {
+					(* If we haven't written any cell yet, then this ``` must
+						be the first thing sent from the LLM, so make the
+						initial cell a code output cell. *)
+					None :> (
+						$state["CurrentOutputType"] = "Code";
+						AppendTo[outputEvents, "BeginCodeBlock"[spec]];
+					),
+					(* If the current cell is a non-code cell, then this
+						"```" must be starting a code block. *)
+					"Text" :> (
+						$state["CurrentOutputType"] = "Code";
+						AppendTo[outputEvents, "BeginCodeBlock"[spec]];
+					),
+					(* If the current cell is a code cell, then this
+						"```" must be ending a code block. *)
+					"Code" :> (
+						(* FIXME: This can fail if ChatGPT generates
+							syntactically invalid Markdown output, which doesn't
+							seem inconveivable. Maybe fail more gracefully if
+							that happens? *)
+						RaiseAssert[spec === ""];
+
+						$state["CurrentOutputType"] = "Text";
+						AppendTo[outputEvents, "BeginText"];
+					)
+				}];
+
+				$state["Buffer"] = rest;
+			),
+			(* Write any other input out directly. *)
+			_ :> (
+				AppendTo[outputEvents, "Write"[$state["Buffer"]]];
+
+				$state["Buffer"] = "";
+			)
+		}];
+	];
+
+	If[outputEvents === {},
+		Missing["IncompleteData"]
+		,
+		outputEvents
+	]
+]
+
+(*========================================================*)
+
+End[]
+
+EndPackage[]

--- a/Source/UI.wl
+++ b/Source/UI.wl
@@ -26,7 +26,7 @@ ChatInputCellEvaluationFunction[
 	tokenLimit,
 	temperature,
 	params,
-	req, response, parsed, content, processed
+	req
 },
 	If[!checkAPIKey[False],
 		Return[]
@@ -99,7 +99,23 @@ ChatInputCellEvaluationFunction[
 	$LastRequestChatMessages = req;
 	$LastRequestParameters = params;
 
-	response = chatRequest[req, params];
+	doSyncChatRequest[req, params]
+]
+
+(*====================================*)
+
+SetFallthroughError[doSyncChatRequest]
+
+doSyncChatRequest[
+	messages_?ListQ,
+	params_?AssociationQ
+] := Module[{
+	response,
+	parsed,
+	content,
+	processed
+},
+	response = chatRequest[messages, params];
 
 	$LastResponse = response;
 

--- a/Source/UI.wl
+++ b/Source/UI.wl
@@ -369,7 +369,7 @@ promptProcess[
 		there are any additional styles that have been specified to include.
 	*)
 	Cell[expr_, styles0___?StringQ, ___?OptionQ] :> Module[{
-		styles = {styles0},
+		styles = {styles0}
 	},
 		(* Only consider styles that are in `includedStyles` *)
 		styles = Intersection[styles, Keys[additionalContextStyles]];

--- a/Source/UI.wl
+++ b/Source/UI.wl
@@ -78,7 +78,7 @@ ChatInputCellEvaluationFunction[
 	(* Put the insertion point where it belongs after the old output        *)
 	(*----------------------------------------------------------------------*)
 
-	moveAfterPreviousOutputs[EvaluationCell[], EvaluationNotebook[]];
+	moveAfterPreviousOutputs[EvaluationCell[]];
 
 	(*----------------------------------------------------------------------*)
 	(* Extract the token limit and temperature from the evaluation cell     *)
@@ -105,7 +105,7 @@ ChatInputCellEvaluationFunction[
 	(* doSyncChatRequest[req, params] *)
 
 
-	deletePreviousOutputs[EvaluationCell[], EvaluationNotebook[]];
+	deletePreviousOutputs[EvaluationCell[]];
 
 	SelectionMove[cell, After, EvaluationCell[]];
 
@@ -207,7 +207,7 @@ doSyncChatRequest[
 
 	processed = StringJoin[StringTrim[content]];
 
-	deletePreviousOutputs[EvaluationCell[], EvaluationNotebook[]];
+	deletePreviousOutputs[EvaluationCell[]];
 
 	processResponse[processed];
 ]
@@ -598,8 +598,11 @@ The FE also does something special if it encounters a cell group. But we're not
 going to bother with that for now.
 *)
 
-previousOutputs[cellobj_, nbobj_] :=
-	Module[{cells, objs = {}},
+previousOutputs[cellobj_CellObject] :=
+	Module[{
+		nbobj = ParentNotebook[cellobj],
+		cells, objs = {}
+	},
 		If[Not @ TrueQ @ AbsoluteCurrentValue[nbobj, OutputAutoOverwrite], Return[{}]];
 		cells = NextCell[cellobj, All];
 		If[!MatchQ[cells, {__CellObject}], Return[{}]];
@@ -613,14 +616,14 @@ previousOutputs[cellobj_, nbobj_] :=
 	]
 
 
-deletePreviousOutputs[cellobj_, nbobj_] :=
-	Replace[previousOutputs[cellobj, nbobj], {
+deletePreviousOutputs[cellobj_CellObject] :=
+	Replace[previousOutputs[cellobj], {
 		cells: {__CellObject} :> NotebookDelete[cells],
 		_ :> None
 	}]
 
-moveAfterPreviousOutputs[cellobj_, nbobj_] :=
-	Replace[previousOutputs[cellobj, nbobj], {
+moveAfterPreviousOutputs[cellobj_CellObject] :=
+	Replace[previousOutputs[cellobj], {
 		{___, lastcell_CellObject} :> SelectionMove[lastcell, After, Cell],
 		_ :> SelectionMove[cellobj, After, Cell]
 	}]

--- a/Source/UI.wl
+++ b/Source/UI.wl
@@ -290,42 +290,36 @@ handleStreamEvent[
 		InputForm[json]
 	];
 
+	data = ConfirmReplace[data, {
+		KeyValuePattern[{
+			(* TODO: What about other possible choices? *)
+			"choices" -> {firstChoice_, ___}
+		}] :> firstChoice,
+		other_ :> Raise[
+			ChatbookError,
+			"Unexpected chat streaming response object form: ``",
+			InputForm[other]
+		]
+	}];
+
 	ConfirmReplace[data, {
 		KeyValuePattern[{
-			"choices" -> {
-				KeyValuePattern[{
-					"delta" -> KeyValuePattern[{
-						"content" -> text_?StringQ
-					}]
-				}],
-				(* TODO: What about other possible choices? *)
-				___
-			}
+			"delta" -> KeyValuePattern[{
+				"content" -> text_?StringQ
+			}]
 		}] :> (
 			NotebookWrite[nbObj, text];
 		),
 		(* FIXME: Handle this change in role by changing cell type if necessary? *)
 		KeyValuePattern[{
-			"choices" -> {
-				KeyValuePattern[{
-					"delta" -> KeyValuePattern[{
-						"role" -> "assistant"
-					}]
-				}],
-				(* TODO: What about other possible choices? *)
-				___
-			}
+			"delta" -> KeyValuePattern[{
+				"role" -> "assistant"
+			}]
 		}] :> Null,
 		(* FIXME: Handle this streaming end better. *)
 		KeyValuePattern[{
-			"choices" -> {
-				KeyValuePattern[{
-					"delta" -> <||>,
-					"finish_reason" -> "stop"
-				}],
-				(* TODO: What about other possible choices? *)
-				___
-			}
+			"delta" -> <||>,
+			"finish_reason" -> "stop"
 		}] :> Null,
 		other_ :> Raise[
 			ChatbookError,

--- a/Source/Utils.wl
+++ b/Source/Utils.wl
@@ -1,0 +1,65 @@
+(*
+	This package contains utility functions that are not tied to Chatbook
+	directly in any way.
+*)
+
+BeginPackage["ConnorGray`Chatbook`Utils`"]
+
+CellPrint2
+
+Begin["`Private`"]
+
+Needs["ConnorGray`Chatbook`ErrorUtils`"]
+Needs["ConnorGray`Chatbook`UI`"]
+
+(*====================================*)
+
+SetFallthroughError[CellPrint2]
+
+(*
+	Alternative to CellPrint[] where the first argument is an evaluation input
+	cell, and the new cell will be printed after any existing output cells.
+
+	`CellPrint[arg]` is conceptually `CellPrint2[EvaluationCell[], arg]`.
+*)
+CellPrint2[
+	evalCell_CellObject,
+	Cell[cellData_, cellStyles___?StringQ, cellOpts___?OptionQ]
+] := With[{
+	uuid = CreateUUID[]
+}, Module[{
+	cell = Cell[
+		cellData,
+		cellStyles,
+		GeneratedCell -> True,
+		CellAutoOverwrite -> True,
+		ExpressionUUID -> uuid,
+		cellOpts
+	],
+	obj
+},
+	RaiseAssert[
+		Experimental`CellExistsQ[evalCell],
+		"Unable to print cell: evaluation cell does not exist."
+	];
+
+	ConnorGray`Chatbook`UI`Private`moveAfterPreviousOutputs[evalCell];
+
+	RaiseConfirm @ NotebookWrite[ParentNotebook[evalCell], cell];
+
+	obj = CellObject[uuid];
+
+	RaiseAssert[
+		Experimental`CellExistsQ[obj],
+		<| "CellExpression" -> cell |>,
+		"Error printing cell: written cell was not created or could not be found."
+	];
+
+	obj
+]]
+
+(*====================================*)
+
+End[]
+
+EndPackage[]

--- a/SourceSSE/ServerSentEventUtils.wl
+++ b/SourceSSE/ServerSentEventUtils.wl
@@ -1,0 +1,96 @@
+BeginPackage["ConnorGray`ServerSentEventUtils`"]
+
+Needs["GeneralUtilities`" -> "GU`"]
+
+GU`SetUsage[ServerSentEventBodyChunkTransformer, "
+ServerSentEventBodyChunkTransformer[func$] transforms a sequence of raw recieved \
+data chunks into a sequence of server-sent events.
+
+ServerSentEventBodyChunkTransformer[func$] constructs a new function that can be \
+used as the value of the \"BodyChunkRecieved\" handler of URLSubmit.
+
+The inner func$ will be called once for each complete server-sent event that is \
+recieved.
+"]
+
+Begin["`Private`"]
+
+Needs["ConnorGray`Chatbook`ErrorUtils`"]
+
+CreateErrorType[ServerSentEventError, {}]
+
+(*====================================*)
+
+SetFallthroughError[ServerSentEventBodyChunkTransformer]
+
+(*
+	See also: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format
+*)
+ServerSentEventBodyChunkTransformer[func_] := Module[{
+	(*
+		This buffer is accumulated to across multiple calls to the
+		transformer function.
+
+		This is necessary to support large events that are sent in multiple
+		TCP packets (i.e. multiple "chunks"). In other works, a single
+		server-sent event may require multiple chunks to be recieved before
+		all of the event data has been recieved.
+	*)
+	buffer = ""
+},
+	Function[args, Module[{
+		chunk,
+		pos,
+		event
+	},
+		chunk = ConfirmReplace[args["BodyChunk"], {
+			c_?StringQ :> c,
+			other_ :> Raise[
+				ServerSentEventError,
+				"Unexpected \"BodyChunk\" value: ``",
+				InputForm[other]
+			]
+		}];
+
+		RaiseAssert[StringQ[buffer]];
+
+		buffer = StringJoin[buffer, chunk];
+
+		(*
+			If `buffer` doesn't contain a "\n\n" substring, then we haven't
+			accumulated enough chunks to end the current message, so this loop
+			won't run.
+		*)
+		While[(pos = StringPosition[buffer, "\n\n", 1]) =!= {},
+			pos = ConfirmReplace[pos, {{start_Integer, _}, ___} :> start];
+
+			(* -1 so we don't include the first \n in `event`. *)
+			event = StringTake[buffer, pos - 1];
+
+			(* +1 to include the second \n. *)
+			buffer = StringDrop[buffer, pos + 1];
+
+			(* Process the textual content of the event into an Association. *)
+			event = Which[
+				StringStartsQ[event, "data: "],
+					<| "Data" -> StringDelete[event, StartOfString ~~ "data: "] |>,
+				True,
+					(* FIXME: Handle other types of event fields. *)
+					Raise[
+						ServerSentEventError,
+						"Invalid server-sent event syntax: ``",
+						InputForm[event]
+					]
+			];
+
+			func[event];
+		];
+	]]
+]
+
+(*====================================*)
+
+
+End[]
+
+EndPackage[]

--- a/Tests/SSETests.wlt
+++ b/Tests/SSETests.wlt
@@ -1,0 +1,31 @@
+Needs["ConnorGray`ServerSentEventUtils`"]
+
+$events = {}
+$func = ServerSentEventBodyChunkTransformer[event |-> AppendTo[$events, event]]
+
+VerificationTest[
+	{
+		$func[<| "BodyChunk" -> "data: " |>],
+		$events
+	}
+	,
+	{Null, {}}
+]
+
+VerificationTest[
+	{
+		$func[<| "BodyChunk" -> "foo\n" |>],
+		$events
+	}
+	,
+	{Null, {}}
+]
+
+VerificationTest[
+	{
+		$func[<| "BodyChunk" -> "\n\n" |>],
+		$events
+	}
+	,
+	{Null, {<| "Data" -> "foo" |>}}
+]

--- a/Tests/SSETests.wlt
+++ b/Tests/SSETests.wlt
@@ -1,5 +1,36 @@
 Needs["ConnorGray`ServerSentEventUtils`"]
 
+
+(*=================================================*)
+(* Test: CreateChunkToServerSentEventGenerator *)
+(*=================================================*)
+
+Module[{
+	generator = CreateChunkToServerSentEventGenerator[]
+},
+	VerificationTest[
+		generator["data:"]
+		,
+		Missing["IncompleteData"]
+	];
+
+	VerificationTest[
+		generator[" foo\n"]
+		,
+		Missing["IncompleteData"]
+	];
+
+	VerificationTest[
+		generator["\n"]
+		,
+		{<|"Data" -> "foo"|>}
+	];
+]
+
+(*===========================================*)
+(* Test: ServerSentEventBodyChunkTransformer *)
+(*===========================================*)
+
 $events = {}
 $func = ServerSentEventBodyChunkTransformer[event |-> AppendTo[$events, event]]
 

--- a/Tests/Streaming.wlt
+++ b/Tests/Streaming.wlt
@@ -1,0 +1,50 @@
+Needs["ConnorGray`Chatbook`Streaming`"]
+
+(*====================================*)
+
+content[str_?StringQ] :=
+	<|
+		"choices" -> {
+			<| "delta" -> <| "content" -> str|> |>
+		}
+	|>;
+
+(*===============================================*)
+(* Test: CreateChatEventToOutputEventGenerator[] *)
+(*===============================================*)
+
+Module[{
+	generator = CreateChatEventToOutputEventGenerator[]
+},
+	VerificationTest[generator[content["Hello\n"]],   {"Write"["Hello"], "Write"["\n"]}];
+	VerificationTest[generator[content["world"]],     {"Write"["world"]}];
+]
+
+(*====================================*)
+
+Module[{
+	generator = CreateChatEventToOutputEventGenerator[]
+},
+	VerificationTest[
+		generator[content["Hello\nworld"]],
+		{
+			"Write"["Hello"], "Write"["\nworld"],
+			(* FIXME: This test output seems incorrect... what causes all
+				these empty writes, and why don't they go on forever? *)
+			"Write"[""], "Write"[""], "Write"[""], "Write"[""], "Write"[""]
+		}
+	];
+]
+
+(*====================================*)
+
+Module[{
+	generator = CreateChatEventToOutputEventGenerator[]
+},
+	VerificationTest[generator[content["``"]],             Missing["IncompleteData"]];
+	VerificationTest[generator[content["`wolfram\n"]],     {"BeginCodeBlock"["wolfram"]}];
+	VerificationTest[generator[content["2+2\n"]],          {"Write"["2+2"], "Write"["\n"]}];
+	VerificationTest[generator[content["``"]],             Missing["IncompleteData"]];
+	(* TODO: Test what happens if this event doens't have a newline. *)
+	VerificationTest[generator[content["`\n"]],            {"BeginText"}];
+]

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -1,0 +1,9 @@
+# Development
+
+## Quick Command Reference
+
+**Run the tests:**
+
+```shell
+$ wolfram-cli paclet test . ./Tests
+```


### PR DESCRIPTION
This PR implements support for the ChatGPT streaming API, so that response tokens are written directly into the notebook when they are received.