### PR TITLE
feature: Use single quote instead of '/' to create new chat input cells

### DIFF
--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -83,7 +83,7 @@ Cell[
     CellFrameColor    -> RGBColor[ "#cfd9e9" ],
     CellMargins       -> { { 66, 25 }, { 5, 8 } },
     CellDingbat       -> Cell[ BoxData @ TemplateBox[ { }, "ChatUserIcon" ], Background -> None ],
-    StyleKeyMapping   -> { " " -> "Text", "*" -> "Item", "/" -> "ChatQuery", "Backspace" -> "Input" },
+    StyleKeyMapping   -> { " " -> "Text", "*" -> "Item", "'" -> "ChatQuery", "Backspace" -> "Input" },
     CellTrayWidgets   -> <| "ChatWidget" -> <| "Visible" -> False |> |>,
     menuInitializer[ "ChatInput", RGBColor[ "#cfd9e9" ] ]
 ]
@@ -94,7 +94,7 @@ Cell[
 Cell[
     StyleData[ "ChatQuery", StyleDefinitions -> StyleData[ "ChatInput" ] ],
     MenuSortingValue -> 1000,
-    StyleKeyMapping  -> { " " -> "Text", "*" -> "Item", "/" -> "ChatSystemInput", "Backspace" -> "ChatInput" },
+    StyleKeyMapping  -> { " " -> "Text", "*" -> "Item", "'" -> "ChatSystemInput", "Backspace" -> "ChatInput" },
     CellFrameColor   -> RGBColor[ "#d3deae" ],
     CellDingbat      -> Cell[ BoxData @ TemplateBox[ { }, "ChatQueryIcon" ], Background -> None ],
     CellTrayWidgets   -> <| "ChatWidget" -> <| "Visible" -> False |> |>,
@@ -108,7 +108,7 @@ Cell[
     StyleData[ "ChatSystemInput", StyleDefinitions -> StyleData[ "ChatInput" ] ],
     MenuSortingValue -> 1000,
     CellFrame        -> 1,
-    StyleKeyMapping  -> { " " -> "Text", "*" -> "Item", "/" -> "ChatContextDivider", "Backspace" -> "ChatQuery" },
+    StyleKeyMapping  -> { " " -> "Text", "*" -> "Item", "'" -> "ChatContextDivider", "Backspace" -> "ChatQuery" },
     CellFrameColor   -> RGBColor[ "#b38794" ],
     CellFrameStyle   -> Dashing @ { Small, Small },
     CellDingbat      -> Cell[ BoxData @ TemplateBox[ { }, "ChatSystemIcon" ], Background -> None ],
@@ -151,7 +151,7 @@ Cell[
 
     StyleKeyMapping -> {
         "~" -> "ChatDelimiter",
-        "/" -> "ChatInput",
+        "'" -> "ChatInput",
         "=" -> "WolframAlphaShort",
         "*" -> "Item",
         ">" -> "ExternalLanguageDefault"
@@ -220,7 +220,7 @@ Cell[
     StyleData[ "Input" ],
     StyleKeyMapping -> {
         "~" -> "ChatDelimiter",
-        "/" -> "ChatInput",
+        "'" -> "ChatInput",
         "=" -> "WolframAlphaShort",
         "*" -> "Item",
         ">" -> "ExternalLanguageDefault"

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -603,7 +603,7 @@ Notebook[
    StyleKeyMapping -> {
     " " -> "Text",
     "*" -> "Item",
-    "/" -> "ChatQuery",
+    "'" -> "ChatQuery",
     "Backspace" -> "Input"
    },
    CellGroupingRules -> "InputGrouping",
@@ -648,7 +648,7 @@ Notebook[
    StyleKeyMapping -> {
     " " -> "Text",
     "*" -> "Item",
-    "/" -> "ChatSystemInput",
+    "'" -> "ChatSystemInput",
     "Backspace" -> "ChatInput"
    },
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,
@@ -693,7 +693,7 @@ Notebook[
    StyleKeyMapping -> {
     " " -> "Text",
     "*" -> "Item",
-    "/" -> "ChatContextDivider",
+    "'" -> "ChatContextDivider",
     "Backspace" -> "ChatQuery"
    },
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,
@@ -778,7 +778,7 @@ Notebook[
    CellMargins -> {{66, 25}, {Inherited, Inherited}},
    StyleKeyMapping -> {
     "~" -> "ChatDelimiter",
-    "/" -> "ChatInput",
+    "'" -> "ChatInput",
     "=" -> "WolframAlphaShort",
     "*" -> "Item",
     ">" -> "ExternalLanguageDefault"
@@ -876,7 +876,7 @@ Notebook[
    StyleData["Input"],
    StyleKeyMapping -> {
     "~" -> "ChatDelimiter",
-    "/" -> "ChatInput",
+    "'" -> "ChatInput",
     "=" -> "WolframAlphaShort",
     "*" -> "Item",
     ">" -> "ExternalLanguageDefault"


### PR DESCRIPTION
This reserves '/' for future use.

@theodoregray @chriswolfram @rhennigan FYI — If you've got muscle memory for typing '/', be advised ' is the new way.