### PR TITLE
Inline the stylesheet when in cloud

### DIFF
--- a/Source/Chatbook/CreateChatNotebook.wl
+++ b/Source/Chatbook/CreateChatNotebook.wl
@@ -75,8 +75,23 @@ makeChatNotebookSettings[ as_Association? AssociationQ, opts: OptionsPattern[ Cr
 makeChatNotebookOptions // SetFallthroughError;
 
 makeChatNotebookOptions[ settings_Association ] := Sequence[
-    StyleDefinitions -> "Chatbook.nb",
+    StyleDefinitions -> $chatbookStylesheet,
     TaggingRules     -> <| "ChatNotebookSettings" -> settings |>
+];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$chatbookStylesheet*)
+$chatbookStylesheet := If[ TrueQ @ CloudSystem`$CloudNotebooks, $inlinedStylesheet, "Chatbook.nb" ];
+
+$inlinedStylesheet := $inlinedStylesheet = Import[
+    FileNameJoin @ {
+        PacletObject[ "Wolfram/Chatbook" ][ "Location" ],
+        "FrontEnd",
+        "StyleSheets",
+        "Chatbook.nb"
+    },
+    "NB"
 ];
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
This PR changes `CreateChatNotebook` so that it will inline the stylesheet when evaluating in cloud. It seems like cloud notebooks cannot see paclet stylesheets, but they do work inline:

<img width="907" alt="image" src="https://user-images.githubusercontent.com/6674723/233511733-7be30cc7-9c3a-47aa-b513-7c32033f052b.png">
